### PR TITLE
feat/delete-alert-measure

### DIFF
--- a/src/api/alertService.ts
+++ b/src/api/alertService.ts
@@ -1,0 +1,5 @@
+import api from './api';
+
+export const alertService = {
+    deleteAlert: (id: string) => api.delete(`/alert/delete/${id}`),
+}

--- a/src/api/measureService.ts
+++ b/src/api/measureService.ts
@@ -1,0 +1,5 @@
+import api from "./api";
+
+export const measureService = {
+    deleteMeasure: (id: string) => api.delete(`/measure/delete/${id}`),
+}

--- a/src/components/TabsStation/alertTab/AlertTab.tsx
+++ b/src/components/TabsStation/alertTab/AlertTab.tsx
@@ -3,14 +3,15 @@ import { ReadStationType } from "../../../types/station/ReadStationType";
 import "../shared/TabStyles.css";
 import DynamicList from "../../list/DynamicList";
 import api from "../../../api/api";
+import { alertService } from "../../../api/alertService";
 import { errorSwal } from "../../swal/errorSwal";
+import { successSwal } from "../../swal/sucessSwal";
 
 export interface ListAlertDTO {
   id: string;
   message: string;
   measure: ListMeasureResponseDTO;
 }
-
 export interface ListMeasureResponseDTO {
   id: string;
   unixTime: number;
@@ -33,6 +34,16 @@ export interface UnifiedAlertDTO {
 
 export default function AlertTab({ station, onUpdateStation }: AlertTabProps) {
   const [alerts, setAlerts] = useState<UnifiedAlertDTO[]>([]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await alertService.deleteAlert(id);
+      setAlerts(alerts.filter((alert) => alert.id !== id));
+      successSwal("Alerta deletado com sucesso");
+    } catch (error) {
+      errorSwal((error as any)?.response?.data?.error || "Erro desconhecido");
+    }
+  }
 
   const getAllAlerts = async () => {
     try {
@@ -74,9 +85,10 @@ export default function AlertTab({ station, onUpdateStation }: AlertTabProps) {
               { key: "value", label: "Valor" },
               { key: "parameterText", label: "Parâmetro" },
             ]}
-            onDelete={(id) => {}}
+            onDelete={handleDelete}
             onUpdate={(id) => {}}
             isEditable={false}
+            isDelete={true}
             text="alertas"
           />
         ) : (

--- a/src/components/TabsStation/measureTab/MeasureTab.tsx
+++ b/src/components/TabsStation/measureTab/MeasureTab.tsx
@@ -4,6 +4,7 @@ import "../shared/TabStyles.css";
 import DynamicList from "../../list/DynamicList";
 import api from "../../../api/api";
 import { errorSwal } from "../../swal/errorSwal";
+import { successSwal } from "../../swal/sucessSwal";
 
 export interface ListMeasureResponseDTO {
   id: string;
@@ -29,6 +30,16 @@ export default function MeasureTab({
   onUpdateStation,
 }: MeasureTabProps) {
   const [measures, setMeasures] = useState<ListMeasure[]>([]);
+
+  const handleDelete = async (id: string) => {
+    try {
+      await api.delete(`/measure/delete/${id}`);
+      setMeasures(measures.filter((measure) => measure.id !== id));
+      successSwal("Medição deletada com sucesso");
+    } catch (error) {
+      errorSwal((error as any)?.response?.data?.error || "Erro desconhecido");
+    }
+  }
 
   const getAllMeasures = async () => {
     try {
@@ -63,9 +74,10 @@ export default function MeasureTab({
               { key: "value", label: "Valor" },
               { key: "parameterText", label: "Parâmetro" },
             ]}
-            onDelete={(id) => {}}
+            onDelete={handleDelete}
             onUpdate={(id) => {}}
             isEditable={false}
+            isDelete={true}
             text="medições"
           />
         ) : (

--- a/src/components/list/DynamicList.tsx
+++ b/src/components/list/DynamicList.tsx
@@ -10,6 +10,7 @@ export interface ListProps<T> {
   onDelete: (id: string) => void;
   onUpdate: (id: string) => void;
   isEditable: boolean;
+  isDelete: boolean;
   detailsLink?: string;
   idKey?: keyof T;
   text?: string;
@@ -22,6 +23,7 @@ function DynamicList<T>({
   onUpdate,
   detailsLink,
   isEditable = detailsLink ? true : false,
+  isDelete = detailsLink ? true : false,
   idKey = "id" as keyof T,
   text,
 }: ListProps<T>) {
@@ -50,7 +52,7 @@ function DynamicList<T>({
   }, [data]);
 
   const gridStyle = {
-    gridTemplateColumns: isEditable
+    gridTemplateColumns: isEditable || isDelete
       ? `repeat(${fields.length}, 1fr) 100px`
       : `repeat(${fields.length}, 1fr)`,
   };
@@ -63,16 +65,19 @@ function DynamicList<T>({
           <span className="mobile-card-value">{String(item[field.key])}</span>
         </div>
       ))}
-      {isEditable && (
-        <div className="mobile-card-actions">
-          <FontAwesomeIcon
-            icon={faEdit}
-            onClick={() => onUpdate(String(item[idKey]))}
-          />
-          <FontAwesomeIcon
+      <div className="mobile-card-actions">
+        {isEditable && (
+            <FontAwesomeIcon
+              icon={faEdit}
+              onClick={() => onUpdate(String(item[idKey]))}
+            />
+          )}
+          {isDelete && (
+            <FontAwesomeIcon
             icon={faTrash}
             onClick={() => onDelete(String(item[idKey]))}
           />
+          )}
           {detailsLink && (
             <FontAwesomeIcon
               icon={faSearch}
@@ -80,7 +85,6 @@ function DynamicList<T>({
             />
           )}
         </div>
-      )}
     </div>
   );
 
@@ -120,7 +124,7 @@ function DynamicList<T>({
                 {field.label}
               </div>
             ))}
-            {isEditable && <div className="list-header-item">Ações</div>}
+            {(isEditable || isDelete) && <div className="list-header-item">Ações</div>}
           </div>
           {filteredData.map((item) => (
             <div key={String(item[idKey])} className="list-row" style={gridStyle}>
@@ -129,16 +133,19 @@ function DynamicList<T>({
                   {String(item[field.key])}
                 </div>
               ))}
-              {isEditable && (
-                <div className="actions-cell">
-                  <FontAwesomeIcon
-                    icon={faEdit}
-                    onClick={() => onUpdate(String(item[idKey]))}
-                  />
-                  <FontAwesomeIcon
+              <div className="actions-cell">
+                {isEditable && (
+                    <FontAwesomeIcon
+                      icon={faEdit}
+                      onClick={() => onUpdate(String(item[idKey]))}
+                    />
+                  )}
+                  {isDelete && (
+                    <FontAwesomeIcon
                     icon={faTrash}
                     onClick={() => onDelete(String(item[idKey]))}
                   />
+                  )}
                   {detailsLink && (
                     <FontAwesomeIcon
                       icon={faSearch}
@@ -146,7 +153,6 @@ function DynamicList<T>({
                     />
                   )}
                 </div>
-              )}
             </div>
           ))}
         </div>

--- a/src/components/modalAdmin/ModalAdmin.tsx
+++ b/src/components/modalAdmin/ModalAdmin.tsx
@@ -9,12 +9,14 @@ interface ModalAdminProps<T> {
   text: string;
   createlink: string;
   style: number;
+  haveButton?: boolean;
   listProps: ListProps<T>;
 }
 
 export default function ModalAdmin({
   createlink,
   listProps,
+  haveButton,
   style,
   text,
 }: ModalAdminProps<any>) {
@@ -25,15 +27,19 @@ export default function ModalAdmin({
         <div className="modal-admin-bg2">
           <div className="modal-admin-header">
             <p className="modal-admin-title">Listagem de {text}</p>
-            <ButtonWithImg
-              style={2}
-              text={`Adicionar ${text}`}
-              icon={faPlus}
-              link={createlink}
-            />
+            {haveButton && (
+              <>
+                <ButtonWithImg
+                  style={2}
+                  text={`Adicionar ${text}`}
+                  icon={faPlus}
+                  link={createlink}
+                />
+              </>
+            )}
           </div>
 
-          {(listProps.data.length === 0) ? (
+          {listProps.data.length === 0 ? (
             <NoData />
           ) : (
             <DynamicList
@@ -42,6 +48,7 @@ export default function ModalAdmin({
               onDelete={listProps.onDelete}
               onUpdate={listProps.onUpdate}
               isEditable={listProps.isEditable}
+              isDelete={listProps.isDelete}
               detailsLink={listProps.detailsLink}
               text={text}
             />

--- a/src/pages/Alert/ListAlert/ListAlert.tsx
+++ b/src/pages/Alert/ListAlert/ListAlert.tsx
@@ -2,6 +2,9 @@ import React, { useEffect, useState } from "react";
 import ModalAdmin from "../../../components/modalAdmin/ModalAdmin";
 import api from "../../../api/api";
 import { UnifiedAlertDTO, ListAlertDTO } from "../../../components/TabsStation/alertTab/AlertTab";
+import { alertService } from "../../../api/alertService";
+import { successSwal } from "../../../components/swal/sucessSwal";
+import { errorSwal } from "../../../components/swal/errorSwal";
 
 // filepath: c:\Users\erikc\OneDrive\Área de Trabalho\API.2025.1\API-4-FRONT\src\pages\Alert\ListAlert\ListAlert.tsx
 
@@ -16,6 +19,16 @@ export interface AlertProps {
 
 const ListAlert: React.FC = () => {
   const [alerts, setAlerts] = useState<UnifiedAlertDTO[]>([]);
+
+    const handleDelete = async (id: string) => {
+      try {
+        await alertService.deleteAlert(id);
+        setAlerts(alerts.filter((alert) => alert.id !== id));
+        successSwal("Alerta deletado com sucesso");
+      } catch (error) {
+        errorSwal((error as any)?.response?.data?.error || "Erro desconhecido");
+      }
+    }
 
   const getAllAlerts = async () => {
     try {
@@ -53,9 +66,10 @@ const ListAlert: React.FC = () => {
             { key: "value", label: "Valor" },
             { key: "parameterText", label: "Parâmetro" },
           ],
-        onDelete: () => {},
+        onDelete: handleDelete,
         onUpdate: () => {},
         isEditable: false,
+        isDelete: true,
       }}
       style={1}
     />

--- a/src/pages/Client/ListClient/ListClient.tsx
+++ b/src/pages/Client/ListClient/ListClient.tsx
@@ -66,12 +66,14 @@ const ListClient: React.FC = () => {
         <ModalAdmin 
             createlink='/usuario/criar'
             text='usuários'
+            haveButton={true}
             listProps={{ 
               data, 
               fields, 
               onDelete: handleDelete, 
               onUpdate: handleUpdate, 
               isEditable: true,
+              isDelete: true,
               idKey: 'id' as keyof UserProps 
             }}
             style={1}

--- a/src/pages/Client/RegisterClient/RegisterClient.tsx
+++ b/src/pages/Client/RegisterClient/RegisterClient.tsx
@@ -17,6 +17,11 @@ function formatCPF(cpf: string) {
   );
 }
 
+// Função para validar o formato do e-mail
+function isValidEmail(email: string): boolean {
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return emailRegex.test(email);
+}
 
 export default function RegisterClient() {
   const navigate = useNavigate();
@@ -32,10 +37,15 @@ export default function RegisterClient() {
   }
 
   const handleSubmit = async () => {
+    if (!isValidEmail(userData.email)) {
+      errorSwal('Por favor, insira um e-mail válido.');
+      return;
+    }
+
     try {
       const response = await userService.registerUser(userData);
       successSwal('Usuário cadastrado com sucesso');
-      navigate("/usuario")
+      navigate("/usuario");
     } catch (error) {
       errorSwal((error as any)?.response?.data?.error || 'Erro desconhecido');
     }

--- a/src/pages/Station/ListStation/ListStation.tsx
+++ b/src/pages/Station/ListStation/ListStation.tsx
@@ -59,12 +59,14 @@ const ListStation: React.FC = () => {
         <ModalAdmin 
             createlink='/estacao/criar'
             text='estações'
+            haveButton={true}
             listProps={{ 
               data, 
               fields, 
               onDelete: handleDelete, 
               onUpdate: handleUpdate, 
               isEditable: true,
+              isDelete: true,
               idKey: 'id' as keyof StationProps, 
               detailsLink: '/estacao/',
             }}

--- a/src/pages/TypeParamter/ListTypeParameter/ListTypeParameter.tsx
+++ b/src/pages/TypeParamter/ListTypeParameter/ListTypeParameter.tsx
@@ -60,12 +60,14 @@ const ListTypeParameter: React.FC = () => {
         <ModalAdmin 
             createlink='/tipo-parametro/criar'
             text='tipos de parâmetros'
+            haveButton={true}
             listProps={{ 
               data, 
               fields, 
               onDelete: handleDelete, 
               onUpdate: handleUpdate, 
               isEditable: true,
+              isDelete: true,
               idKey: 'id' as keyof TypeParameterProps 
             }}
             style={1}


### PR DESCRIPTION
# Deletar medidas e alertas

## Branch
- feat/delete-alert-measure

## Changelog:
- Coloquei validação de email na hora de cadastrar um funcionário.
- Coloquei a opção de ser só deletavel ou editavel na lista dinamica.
- Atribui métodos para realizar as requisições de deletar as medidas e alertas.
- Somente administrador deve conseguir deletar.
- Removi botão de criar alertas na página de listagem de alertas.
- Adicionei uma lógica para verificar se existe o botão na visão de admin.

## Como Testar:
- Acesse o modal de criar o usuário e tente colocar um email inválido.
- Acesse os detalhes de uma estação vá para área de alertas e visualize o botão de deletar, tente deletar como funcionário e depois como admin.
- Refaça os mesmos passos anterior mas como medidas.
- Acesse a página de listagem de alertas verifique se não existe um botão de criar alertas e tente usar o botão de deletar.

## Dependências:
- Nenhuma.