### PR TITLE
feat/A20-105/Ajustar-alinhamento-de-texto-da-aplicacao

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -8,7 +8,6 @@
   box-sizing: border-box;
   text-decoration: none;
   list-style: none;
-  text-align: justify;
 }
 
 :root {

--- a/src/pages/LandingPage/LandingPage.css
+++ b/src/pages/LandingPage/LandingPage.css
@@ -13,6 +13,7 @@
 
 .LandingPage p {
     color: var(--mulberry);
+    text-align: justify;
 }
 
 .LandingPageHeader {


### PR DESCRIPTION
# A20-105-Ajustar-alinhamento-de-texto-da-aplicacao

## Branch
- feat/A20-105-Ajustar-alinhamento-de-texto-da-aplicacao

## Changelog:
- Tirei o text-align que era definido no global para aplicado somente na landing page.

## Como Testar:
- Verifique o alinhamento de texto da landing page se está justificado.
- Verifique se o alinhamento de texto dos botões nos modais estão centralizados.

## Dependências:
- Nenhuma.