### PR TITLE
feat/a20-132/pagina-e-filtro-para-medias-de-medidas

### DIFF
--- a/src/api/dashboardService.ts
+++ b/src/api/dashboardService.ts
@@ -7,6 +7,7 @@ export interface DashboardFilters {
 }
 
 const dashboardService = {
+  getDashboard: (filters?: DashboardFilters) => api.get('/dashboard/public'),
   listDashboard: (filters?: DashboardFilters) =>
     api.get('/dashboard/list', {
       params: filters,

--- a/src/api/measureAverageService.ts
+++ b/src/api/measureAverageService.ts
@@ -1,0 +1,7 @@
+import api from "./api";
+
+export const measureAverageService = {
+    getMeasureAverageLast7Days: (stationId: string) => api.get(`/measureAverage/public/${stationId}`),
+    getMeasureAverageDate: (stationId: string, date: string) => api.get(`/measureAverage/${stationId}/${date}`),
+    getMeasureAverageBetweenDates: (stationId: string, startDate: string, endDate: string) => api.get(`/measureAverage/${stationId}/${startDate}/${endDate}`),
+}

--- a/src/components/TabsStation/dashboardTab/dashboardTab.tsx
+++ b/src/components/TabsStation/dashboardTab/dashboardTab.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { ReadStationType } from '../../../types/station/ReadStationType';
 import Dashboard, { Parameter } from '../../../components/dashboard/dashboard';
 import dashboardService from '../../../api/dashboardService';
 import '../shared/TabStyles.css';
 import Button from '../../../components/button/Button';
+import { AuthContext } from '../../../contexts/auth/AuthContext';
 
 export interface DashboardFilters {
     date?: string;
@@ -41,11 +42,12 @@ export default function DashboardStationTab({ station }: DashboardStationTabProp
     const [singleDate, setSingleDate] = useState('');
     const [startDate, setStartDate] = useState('');
     const [endDate, setEndDate] = useState('');
+    const authContenxt = useContext(AuthContext)
 
     const fetchData = async (filters?: DashboardFilters) => {
         setLoading(true);
         try {
-            const response = await dashboardService.listDashboard(filters);
+            const response = await dashboardService.getDashboard(filters);
             const stations: ApiStation[] = response.data.model.stations;
             const found = stations.find(s => s.id === station.id);
             let params: ApiParameter[] = found ? found.parameters : [];
@@ -103,6 +105,8 @@ export default function DashboardStationTab({ station }: DashboardStationTabProp
                 <h2 className="station-tab__title">Dashboard</h2>
             </div>
 
+            {authContenxt.isAuthenticated && (
+
             <div className="station-tab__filter">
                 <div className="style-select-1 filter-type">
                     <label>
@@ -152,6 +156,7 @@ export default function DashboardStationTab({ station }: DashboardStationTabProp
                         styleButton={1}
                     />   
             </div>
+            )}
 
             <div className="station-tab__content">
                 {loading ? (

--- a/src/components/TabsStation/measureAverageTab/measureAverageTab.tsx
+++ b/src/components/TabsStation/measureAverageTab/measureAverageTab.tsx
@@ -1,0 +1,169 @@
+import { useContext, useEffect, useState } from "react";
+import { ReadStationType } from "../../../types/station/ReadStationType";
+import "../shared/TabStyles.css";
+import DynamicList from "../../list/DynamicList";
+import api from "../../../api/api";
+import { errorSwal } from "../../swal/errorSwal";
+import { successSwal } from "../../swal/sucessSwal";
+import { measureAverageService } from "../../../api/measureAverageService";
+import Button from "../../button/Button";
+import { AuthContext } from "../../../contexts/auth/AuthContext";
+
+export interface ListMeasureAverageResponseDTO {
+  id: string;
+  typeAverage: number;
+  name: string;
+  value: string;
+  createdAt: string;
+}
+
+interface MeasureTabProps {
+  station: ReadStationType;
+  onUpdateStation: () => void;
+}
+
+export default function measureAverageTab({
+  station,
+  onUpdateStation,
+}: MeasureTabProps) {
+  const [measures, setMeasures] = useState<ListMeasureAverageResponseDTO[]>([]);
+  const [filterType, setFilterType] = useState<string>("single");
+  const [singleDate, setSingleDate] = useState<string>("");
+  const [startDate, setStartDate] = useState<string>("");
+  const [endDate, setEndDate] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(false);
+  const authContenxt = useContext(AuthContext)
+
+  const getAllMeasures = async () => {
+    try {
+      const response = await measureAverageService.getMeasureAverageLast7Days(station.id);
+      setMeasures(transformResponse(response.data.model));
+    } catch (error) {
+    }
+  };
+
+  useEffect(() => {
+    getAllMeasures();
+  }, []);
+
+  const transformTypeAverage = (typeAverage: number) => {
+    return typeAverage === 0 ? "Média horária" : "Média diária";
+  }
+
+  const transformResponse = (response: any[]) => {
+    return response.map((measure: any) => ({
+      ...measure,
+      createdAt: new Date(measure.createdAt).toLocaleString("pt-BR"),
+      typeAverage: transformTypeAverage(measure.typeAverage),
+    }));
+  }
+
+  const handleFilter = async () => {
+    setLoading(true);
+  
+    try {
+      let response;
+  
+      if (filterType === "single") {
+        response = singleDate
+          ? await measureAverageService.getMeasureAverageDate(station.id, singleDate)
+          : await measureAverageService.getMeasureAverageLast7Days(station.id);
+      } else {
+        response = (startDate && endDate)
+          ? await measureAverageService.getMeasureAverageBetweenDates(station.id, startDate, endDate)
+          : await measureAverageService.getMeasureAverageLast7Days(station.id);
+      }
+  
+      setMeasures(transformResponse(response.data.model));
+    } catch (error: any) {
+      const errorMsg = error?.response?.data?.error || "Erro desconhecido";
+      errorSwal(errorMsg);
+    } finally {
+      setLoading(false);
+    }
+  };
+  
+
+  return (
+      <div className="station-tab">
+            <div className="station-tab__header">
+                <h2 className="station-tab__title">Médias de medições</h2>
+            </div>
+
+            {authContenxt.isAuthenticated && (
+
+            <div className="station-tab__filter">
+                <div className="style-select-1 filter-type">
+                    <label>
+                        <input
+                            type="radio"
+                            checked={filterType === 'single'}
+                            onChange={() => setFilterType('single')}
+                        />{' '}
+                        Data única
+                    </label>
+                    <label>
+                        <input
+                            type="radio"
+                            checked={filterType === 'interval'}
+                            onChange={() => setFilterType('interval')}
+                        />{' '}
+                        Intervalo
+                    </label>
+                </div>
+
+                {filterType === 'single' ? (
+                    <div className="input-container style-input-2">
+                        <input
+                            type="date"
+                            value={singleDate}
+                            onChange={e => setSingleDate(e.target.value)}
+                        />
+                    </div>
+                ) : (
+                    <div className="input-container style-input-2">
+                        <input
+                            type="date"
+                            value={startDate}
+                            onChange={e => setStartDate(e.target.value)}
+                        />
+                        <span className="list"> até </span>
+                        <input
+                            type="date"
+                            value={endDate}
+                            onChange={e => setEndDate(e.target.value)}
+                        />
+                    </div>
+                )}       
+                    <Button
+                        label={loading ? 'Carregando...' : 'Filtrar'}
+                        onClick={handleFilter}
+                        styleButton={1}
+                    />   
+            </div>
+            )}
+      <div className="station-tab__content">
+        {measures.length > 0 ? (
+          <DynamicList
+            data={measures}
+            fields={[
+              { key: "createdAt", label: "Data" },
+              { key: "value", label: "Valor" },
+              { key: "name", label: "Parâmetro" },
+              { key: "typeAverage", label: "Tipo de média" },
+            ]}
+            onDelete={() => {}}
+            onUpdate={() => {}}
+            isEditable={false}
+            isDelete={false}
+            text="médias de medições"
+          />
+        ) : (
+          <p className="station-tab__empty-message">
+            Nenhuma média de medição registrada para esta estação
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Station/DetailsStation/DetailsStation.tsx
+++ b/src/pages/Station/DetailsStation/DetailsStation.tsx
@@ -15,7 +15,7 @@ import axios from "axios";
 import { successSwal } from "../../../components/swal/sucessSwal";
 import api from "../../../api/api";
 import DashboardTab from "../../../components/TabsStation/dashboardTab/dashboardTab";
-
+import MeasureAverageTab from "../../../components/TabsStation/measureAverageTab/measureAverageTab";
 export default function DetailsStation() {
   const id = useParams().id;
   const [station, setStation] = useState<ReadStationType | null>(null);
@@ -60,8 +60,8 @@ export default function DetailsStation() {
     { id: "typeAlerts", label: "Tipos de alertas" },
     { id: "alerts", label: "Alertas" },
     { id: "measures", label: "Medições" },
+    { id: "measureAverage", label: "Médias de medições" },
     { id: "dashboard", label: "Dashboard" },
-
   ];
 
   const renderTabContent = () => {
@@ -102,6 +102,10 @@ export default function DetailsStation() {
       case "dashboard":
         return (
           <DashboardTab station={station} onUpdateStation={handleReadStation} />
+        )
+      case "measureAverage":
+        return (
+          <MeasureAverageTab station={station} onUpdateStation={handleReadStation} />
         )
       default:
         return null;


### PR DESCRIPTION
# Criar pagina e filtro para medias de medidas

## Branch
- feat/a20-132/pagina-e-filtro-para-medias-de-medidas

## Changelog:
- Criei tela de listagem de medias de medidas
- caso o usuario nao esteja logado so pode filtrar dados dos utlimos sete dias

## Como Testar:
- Entre na pagina e teste os filtros
![image](https://github.com/user-attachments/assets/72262800-57e1-485d-81f7-ecff574b30db)

## Dependências:
- npm i