### PR TITLE
style/A20-156/fazer-com-que-o-titulo-que-contem-os-detalhes-da-estacao-fique-fixo-na-tela

### DIFF
--- a/src/pages/Station/DetailsStation/DetailsStation.css
+++ b/src/pages/Station/DetailsStation/DetailsStation.css
@@ -80,13 +80,26 @@
 }
 
 .details-station-header {
+    position: sticky;
+    top: 10px;
+    z-index: 10;
+    background-color: var(--lavender-light);
     display: flex;
-    justify-content: space-between;
     align-items: center;
     margin-bottom: 20px;
     flex-wrap: wrap;
     gap: 15px;
-    padding: 0 10px;
+    padding: 15px;
+    border-bottom: 0.5px solid var(--lavender-pale);
+    border-radius: 8px;
+}
+
+.name-station {
+    font-size: 12px;
+}
+
+.details-station-icon {
+    color: var(--deep-indigo)
 }
 
 .details-station-title {
@@ -128,15 +141,23 @@
     }
 
     .details-station-header {
-        flex-direction: column;
-        align-items: flex-start;
-        gap: 10px;
-        margin-bottom: 15px;
+        display: flex;
+        top: 65px;
+        flex-direction: row; /* Alinha os itens em linha */
+        justify-content: flex-start; /* Alinha os itens à esquerda */
+        align-items: center; /* Centraliza verticalmente */
+        gap: 10px; /* Ajusta o espaçamento entre os itens */
+    }
+
+    .details-station-icon {
+        flex-shrink: 0; /* Garante que o ícone não encolha */
     }
 
     .details-station-title {
         font-size: 1.2rem;
+        flex: 1; /* Permite que o título ocupe o espaço restante */
         text-align: start;
+        word-break: break-word; /* Quebra o texto longo para evitar sobreposição */
     }
 
     .list-container {
@@ -167,12 +188,16 @@
     }
 
     .details-station-header {
-        padding: 0 5px;
-        margin-bottom: 10px;
+        top: 60px;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: center;
+        gap: 5px;
     }
 
     .details-station-title {
         font-size: 1.1rem;
+        word-break: break-word; /* Garante que o texto não ultrapasse os limites */
     }
 
     .list-container {

--- a/src/pages/Station/DetailsStation/DetailsStation.tsx
+++ b/src/pages/Station/DetailsStation/DetailsStation.tsx
@@ -17,6 +17,8 @@ import api from "../../../api/api";
 import DashboardTab from "../../../components/TabsStation/dashboardTab/dashboardTab";
 import MeasureAverageTab from "../../../components/TabsStation/measureAverageTab/measureAverageTab";
 import { AuthContext } from "../../../contexts/auth/AuthContext";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faRss } from "@fortawesome/free-solid-svg-icons";
 export default function DetailsStation() {
   const id = useParams().id;
   const [station, setStation] = useState<ReadStationType | null>(null);
@@ -135,8 +137,12 @@ export default function DetailsStation() {
       <div className="modal-admin-content">
         <div className="modal-admin-bg2">
           <div className="details-station-header">
+            <FontAwesomeIcon icon={faRss} className="details-station-icon" />
             <h1 className="details-station-title">
-              Detalhes da estação {station?.uuid || "Carregando..."}
+                Detalhes da estação {station?.uuid || "Carregando..."}
+              <div>
+                <p className="name-station">{station?.name || "Carregando..."}</p>
+              </div>
             </h1>
             {!authContext.isAuthenticated && (
               <button


### PR DESCRIPTION
# Fazer com que o titulo que contém os detalhes da estação fique fixo na tela, melhorando a experiência do usuário

## Branch
- style/A20-156/fazer-com-que-o-titulo-que-contem-os-detalhes-da-estacao-fique-fixo-na-tela

## Changelog:
- Fiz com que quando o usuário acesse os detalhes da estação o uid e nome da estação fica fixo na tela.

## Como Testar:
- Rode a aplicação
- Acesse os detalhes de qualquer estação
- Faça uma rolagem na página e verifique se o titulo contendo o uid e o nome da estação fica fixo na tela.

## Dependências:
- Nenhuma.