### PR TITLE
Feat/a20-163/adicionar-gatilho-para-gerar-e-baixar-o-pdf

### DIFF
--- a/src/utils/downloadPdf.ts
+++ b/src/utils/downloadPdf.ts
@@ -1,0 +1,11 @@
+export function downloadPdf(arrayBuffer: ArrayBuffer, fileName: string) {
+  const blob = new Blob([arrayBuffer], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = fileName;
+  a.click();
+
+  URL.revokeObjectURL(url); // libera a memória
+}


### PR DESCRIPTION
# Adicionar gatilho para gerar e baixar o PDF

## Branch
- Feat/a20-163/adicionar-gatilho-para-gerar-e-baixar-o-pdf

## Changelog:
- Adicionar uma função de trasnformar array byte e clicar o botão

## Como Testar:
- Abre o estação e clicar em download

## Dependências:
- npm install 